### PR TITLE
Correcting the POM to depend on Dropwizard version 0.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <github.global.server>github</github.global.server>
 
-        <dropwizard.version>0.9.1</dropwizard.version>
+        <dropwizard.version>0.9.0</dropwizard.version>
         <hibernate.version>4.3.11.Final</hibernate.version>
         <hsqldb.version>2.3.3</hsqldb.version>
         <jackson.version>2.6.3</jackson.version>

--- a/src/main/java/com/scottescue/dropwizard/entitymanager/EntityManagerBundle.java
+++ b/src/main/java/com/scottescue/dropwizard/entitymanager/EntityManagerBundle.java
@@ -50,9 +50,9 @@ public abstract class EntityManagerBundle<T extends Configuration> implements Co
         environment.healthChecks().register(name(),
                 new EntityManagerFactoryHealthCheck(
                         environment.getHealthCheckExecutorService(),
-                        dbConfig.getValidationQueryTimeout().or(Duration.seconds(5)),
+                        dbConfig.getHealthCheckValidationTimeout().or(Duration.seconds(5)),
                         entityManagerFactory,
-                        dbConfig.getValidationQuery()));
+                        dbConfig.getHealthCheckValidationQuery()));
     }
 
     private UnitOfWorkApplicationListener registerUnitOfWorkListerIfAbsent(Environment environment) {


### PR DESCRIPTION
I've addressed a few compile errors due to different method names in the older Dropwizard version.

Fixes #11 
