### PR TITLE
Upgrading to Hibernate 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <dropwizard.version>1.0.0</dropwizard.version>
-        <hibernate.version>4.3.11.Final</hibernate.version>
+        <hibernate.version>5.1.0.Final</hibernate.version>
     </properties>
 
     <developers>
@@ -86,27 +86,15 @@
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
-            <artifactId>jackson-datatype-hibernate4</artifactId>
-            <!-- TODO: Remove explicit version when this is updated to hibernate 5 -->
-            <version>2.7.6</version>
+            <artifactId>jackson-datatype-hibernate5</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jadira.usertype</groupId>
             <artifactId>usertype.core</artifactId>
-            <!-- TODO: Remove explicit version when this is updated to hibernate 5 -->
-            <version>4.0.0.GA</version>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-core</artifactId>
-            <!-- TODO: Remove explicit version and exclusion when this is updated to hibernate 5 -->
-            <version>${hibernate.version}</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.jboss.logging</groupId>
-                    <artifactId>jboss-logging</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.hibernate</groupId>

--- a/src/main/java/com/scottescue/dropwizard/entitymanager/EntityManagerBundle.java
+++ b/src/main/java/com/scottescue/dropwizard/entitymanager/EntityManagerBundle.java
@@ -1,6 +1,6 @@
 package com.scottescue.dropwizard.entitymanager;
 
-import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.google.common.collect.ImmutableList;
 import io.dropwizard.Configuration;
 import io.dropwizard.ConfiguredBundle;
@@ -67,7 +67,7 @@ public abstract class EntityManagerBundle<T extends Configuration> implements Co
     }
 
     public void initialize(Bootstrap<?> bootstrap) {
-        bootstrap.getObjectMapper().registerModule(createHibernate4Module());
+        bootstrap.getObjectMapper().registerModule(createHibernate5Module());
     }
 
     public EntityManagerFactory getEntityManagerFactory() {
@@ -79,10 +79,10 @@ public abstract class EntityManagerBundle<T extends Configuration> implements Co
     }
 
     /**
-     * Override to configure the {@link Hibernate4Module}.
+     * Override to configure the {@link Hibernate5Module}.
      */
-    protected Hibernate4Module createHibernate4Module() {
-        return new Hibernate4Module();
+    protected Hibernate5Module createHibernate5Module() {
+        return new Hibernate5Module();
     }
 
     /**

--- a/src/main/java/com/scottescue/dropwizard/entitymanager/PersistenceUnitConfig.java
+++ b/src/main/java/com/scottescue/dropwizard/entitymanager/PersistenceUnitConfig.java
@@ -1,6 +1,8 @@
 package com.scottescue.dropwizard.entitymanager;
 
 import org.hibernate.jpa.HibernatePersistenceProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.persistence.SharedCacheMode;
 import javax.persistence.ValidationMode;
@@ -13,6 +15,17 @@ import java.util.*;
  * Provides a means to configure {@link javax.persistence.PersistenceUnit} options.
  */
 public abstract class PersistenceUnitConfig {
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceUnitConfig.class);
+
+    @SuppressWarnings("deprecation")
+    private static final Set<String> UNSUPPORTED_ENHANCER_PROPERTIES = new HashSet<String>() {{
+        add( org.hibernate.jpa.AvailableSettings.ENHANCER_ENABLE_DIRTY_TRACKING );
+        add( org.hibernate.jpa.AvailableSettings.ENHANCER_ENABLE_LAZY_INITIALIZATION );
+        add( org.hibernate.jpa.AvailableSettings.ENHANCER_ENABLE_ASSOCIATION_MANAGEMENT );
+        // The USE_CLASS_ENHANCER property is deprecated, but we still need to check whether a value is passed for it
+        add( org.hibernate.jpa.AvailableSettings.USE_CLASS_ENHANCER );
+    }};
+
     protected final String persistenceUnitName;
     protected final String persistenceProviderClassName = HibernatePersistenceProvider.class.getName();
     protected final PersistenceUnitTransactionType transactionType = PersistenceUnitTransactionType.RESOURCE_LOCAL;
@@ -59,6 +72,9 @@ public abstract class PersistenceUnitConfig {
     }
 
     public PersistenceUnitConfig setProperty(String property, String value) {
+        if (UNSUPPORTED_ENHANCER_PROPERTIES.contains(property) && Boolean.valueOf(value)) {
+            LOGGER.warn("Dropwizard EntityManager does not support Hibernate's bytecode enhancer, however the " + property + " property is set to true.  Hibernate's bytecode enhancer will be ignored.");
+        }
         this.properties.setProperty(property, value);
         return this;
     }

--- a/src/main/java/com/scottescue/dropwizard/entitymanager/PersistenceUnitInfoImpl.java
+++ b/src/main/java/com/scottescue/dropwizard/entitymanager/PersistenceUnitInfoImpl.java
@@ -1,5 +1,8 @@
 package com.scottescue.dropwizard.entitymanager;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.persistence.SharedCacheMode;
 import javax.persistence.ValidationMode;
 import javax.persistence.spi.ClassTransformer;
@@ -13,6 +16,8 @@ import java.util.Properties;
 import java.util.Set;
 
 class PersistenceUnitInfoImpl extends PersistenceUnitConfig implements PersistenceUnitInfo {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PersistenceUnitInfoImpl.class);
 
     PersistenceUnitInfoImpl(String persistenceUnitName, DataSource nonJtaDataSource) {
         super(persistenceUnitName, nonJtaDataSource);
@@ -95,12 +100,14 @@ class PersistenceUnitInfoImpl extends PersistenceUnitConfig implements Persisten
 
     @Override
     public void addTransformer(ClassTransformer transformer) {
-        throw new UnsupportedOperationException("addTransformer is not supported");
+        if (transformer != null) {
+            LOGGER.info("Dropwizard EntityManager does not support JPA class transformation.  The " + transformer.getClass().getName() + " class transformer will be ignored.");
+        }
     }
 
     @Override
     public ClassLoader getNewTempClassLoader() {
-        throw new UnsupportedOperationException("getNewTempClassLoader is not supported");
+        return new TemporaryClassLoader(getClassLoader());
     }
 
     /*

--- a/src/main/java/com/scottescue/dropwizard/entitymanager/TemporaryClassLoader.java
+++ b/src/main/java/com/scottescue/dropwizard/entitymanager/TemporaryClassLoader.java
@@ -14,13 +14,13 @@ import java.io.InputStream;
 /**
  * ClassLoader implementation that allows classes to be temporarily loaded and then thrown away.
  */
-public class TemporaryClassLoader extends ClassLoader {
+class TemporaryClassLoader extends ClassLoader {
     private static final String[] PROTECTED_PACKAGES =
             new String[] {"java", "javax", "jdk", "sun", "oracle", "ibm", "IBM"};
 
     private ClassPool classPool = new ClassPool();
 
-    public TemporaryClassLoader(ClassLoader parent) {
+    TemporaryClassLoader(ClassLoader parent) {
         super(parent);
     }
 

--- a/src/main/java/com/scottescue/dropwizard/entitymanager/TemporaryClassLoader.java
+++ b/src/main/java/com/scottescue/dropwizard/entitymanager/TemporaryClassLoader.java
@@ -1,0 +1,140 @@
+package com.scottescue.dropwizard.entitymanager;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.hibernate.engine.jdbc.StreamUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+class TemporaryClassLoader extends ClassLoader {
+
+    interface ClassLoaderOperations {
+        void resolveClass(Class<?> type);
+
+        Class<?> defineClass(String name, byte[] bytes) throws ClassFormatError;
+
+        Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException;
+
+        InputStream getResourceAsStream(String name);
+
+        void copyStreams(InputStream inputStream, OutputStream outputStream) throws IOException;
+    }
+
+
+    private static final String[] EXCLUDED_PACKAGES = new String[] {
+            "java.",
+            "javafx.",
+            "javax.",
+            "sun.",
+            "oracle.",
+            "org.omg.",
+            "org.w3c.",
+            "org.xml.",
+            "javassist.",
+            "net.bytebuddy.",
+            "org.apache.",
+            "org.eclipse.jetty.",
+            "org.glassfish.",
+            "org.slf4j."
+    };
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+
+
+    private final ClassLoaderOperations operations;
+
+
+    TemporaryClassLoader(ClassLoader parent) {
+        super(parent);
+        this.operations = new ClassLoaderOperations() {
+            @Override
+            public void resolveClass(Class<?> type) {
+                TemporaryClassLoader.this.resolveClass(type);
+            }
+
+            @Override
+            public Class<?> defineClass(String name, byte[] bytes) throws ClassFormatError {
+                return TemporaryClassLoader.this.defineClass(name, bytes, 0, bytes.length);
+            }
+
+            @Override
+            public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+                return TemporaryClassLoader.super.loadClass(name, resolve);
+            }
+
+            @Override
+            public InputStream getResourceAsStream(String name) {
+                return TemporaryClassLoader.this.getResourceAsStream(name);
+            }
+
+            @Override
+            public void copyStreams(InputStream inputStream, OutputStream outputStream) throws IOException {
+                StreamUtils.copy(inputStream, outputStream, 4096);
+            }
+        };
+    }
+
+    TemporaryClassLoader(ClassLoader parent, ClassLoaderOperations operations) {
+        super(parent);
+        this.operations = operations;
+    }
+
+
+    @Override
+    protected Class<?> loadClass(String className, boolean resolve) throws ClassNotFoundException {
+        if (!isExcluded(className)) {
+            synchronized (getClassLoadingLock(className)) {
+                Class<?> result = findLoadedClass(className);
+                if (result == null) {
+                    result = findAndDefineClass(className);
+                }
+                if (resolve) {
+                    operations.resolveClass(result);
+                }
+                return result;
+            }
+        } else {
+            return operations.loadClass(className, resolve);
+        }
+    }
+
+    @VisibleForTesting
+    boolean isExcluded(String className) {
+        for (String packageName : EXCLUDED_PACKAGES) {
+            if (className.startsWith(packageName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private Class<?> findAndDefineClass(String className) throws ClassNotFoundException {
+        byte[] bytes = loadBytesForClass(className);
+        if (bytes != null) {
+            return operations.defineClass(className, bytes);
+        }
+        throw new ClassNotFoundException("Cannot load class " + className);
+    }
+
+    private byte[] loadBytesForClass(String className) throws ClassNotFoundException {
+        String internalName = className.replace('.', '/') + ".class";
+        try (
+                InputStream inputStream = operations.getResourceAsStream(internalName);
+                ByteArrayOutputStream outputStream = new ByteArrayOutputStream()
+        ){
+            if (inputStream == null) {
+                return null;
+            }
+            // Load the raw bytes.
+            operations.copyStreams(inputStream, outputStream);
+            return outputStream.toByteArray();
+        } catch (IOException ex) {
+            throw new ClassNotFoundException("Cannot load resource for class [" + className + "]", ex);
+        }
+    }
+
+}

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/EntityManagerBundleTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/EntityManagerBundleTest.java
@@ -3,7 +3,7 @@ package com.scottescue.dropwizard.entitymanager;
 import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.hibernate4.Hibernate4Module;
+import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 import com.google.common.collect.ImmutableList;
 import com.scottescue.dropwizard.entitymanager.entity.Person;
 import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg.FakeEntity1;
@@ -82,7 +82,7 @@ public class EntityManagerBundleTest {
         final ArgumentCaptor<Module> captor = ArgumentCaptor.forClass(Module.class);
         verify(objectMapperFactory).registerModule(captor.capture());
 
-        assertThat(captor.getValue()).isInstanceOf(Hibernate4Module.class);
+        assertThat(captor.getValue()).isInstanceOf(Hibernate5Module.class);
     }
 
     @Test

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/EntityManagerFactoryFactoryTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/EntityManagerFactoryFactoryTest.java
@@ -21,7 +21,6 @@ import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.*;
 
 public class EntityManagerFactoryFactoryTest {
@@ -41,6 +40,7 @@ public class EntityManagerFactoryFactoryTest {
 
     @Before
     public void setUp() throws Exception {
+        when(bundle.name()).thenReturn(getClass().getSimpleName() + "-bundle");
         when(environment.metrics()).thenReturn(metricRegistry);
         when(environment.lifecycle()).thenReturn(lifecycleEnvironment);
 

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/EntityManagerFactoryHealthCheckTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/EntityManagerFactoryHealthCheckTest.java
@@ -9,7 +9,6 @@ import javax.persistence.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
-import static org.mockito.Mockito.never;
 
 public class EntityManagerFactoryHealthCheckTest {
     private final EntityManagerFactory factory = mock(EntityManagerFactory.class);

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/PersistenceUnitConfigTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/PersistenceUnitConfigTest.java
@@ -7,7 +7,7 @@ import javax.persistence.ValidationMode;
 import javax.sql.DataSource;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 public class PersistenceUnitConfigTest {
     private final DataSource dataSource = mock(DataSource.class);
@@ -17,7 +17,7 @@ public class PersistenceUnitConfigTest {
     // the tests stay focused on PersistenceUnitConfig, rather than its implementation, a PersistenceUnitConfig typed
     // handle is created.  Test methods exercise the methods exposed through the PersistenceUnitConfig handle, but assert
     // against the implementation handle.
-    private final PersistenceUnitInfoImpl persistenceUnitInfo = new PersistenceUnitInfoImpl("default-test", dataSource);
+    private final PersistenceUnitInfoImpl persistenceUnitInfo = new PersistenceUnitInfoImpl(getClass().getSimpleName(), dataSource);
     private final PersistenceUnitConfig persistenceUnitConfig = persistenceUnitInfo;
 
     @Test
@@ -80,14 +80,11 @@ public class PersistenceUnitConfigTest {
         assertThat(persistenceUnitInfo.getPersistenceXMLSchemaVersion()).isEqualTo("2.1");
     }
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testAddingTransformerIsUnsupported() {
-        persistenceUnitInfo.addTransformer(
-                (loader, className, classBeingRedefined, protectionDomain, classfileBuffer) -> new byte[0]);
-    }
+    @Test
+    public void testTempClassLoaderIsOfCorrectType() throws Exception {
+        ClassLoader tempClassLoader = persistenceUnitInfo.getNewTempClassLoader();
 
-    @Test(expected = UnsupportedOperationException.class)
-    public void testGettingNewTempClassLoaderIsUnsupported() {
-        persistenceUnitInfo.getNewTempClassLoader();
+        assertThat(tempClassLoader).isNotNull();
+        assertThat(tempClassLoader).isInstanceOf(TemporaryClassLoader.class);
     }
 }

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/TemporaryClassLoaderTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/TemporaryClassLoaderTest.java
@@ -1,0 +1,126 @@
+package com.scottescue.dropwizard.entitymanager;
+
+import com.scottescue.dropwizard.entitymanager.entity.Person;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+
+public class TemporaryClassLoaderTest {
+
+    private final TemporaryClassLoader.ClassLoaderOperations operations =
+            mock(TemporaryClassLoader.ClassLoaderOperations.class);
+
+    private final TemporaryClassLoader temporaryClassLoader = new TemporaryClassLoader(
+            Thread.currentThread().getContextClassLoader(),
+            operations);
+
+    @Before
+    public void setup() {
+        when(operations.defineClass(anyString(), any())).thenAnswer(invocation -> {
+            final String name = invocation.getArgument(0);
+            return Thread.currentThread().getContextClassLoader().loadClass(name);
+        });
+
+        when(operations.getResourceAsStream(anyString())).thenAnswer(invocation -> {
+            final String name = invocation.getArgument(0);
+            return Thread.currentThread().getContextClassLoader().getResourceAsStream(name);
+        });
+    }
+
+    @Test
+    public void allowedClassIsNotResolveWhenNotAsked() throws Exception {
+        temporaryClassLoader.loadClass(Person.class.getName(), false);
+
+        verify(operations, never()).resolveClass(any());
+    }
+
+    @Test
+    public void allowedClassIsResolvedWhenAsked() throws Exception {
+        temporaryClassLoader.loadClass(Person.class.getName(), true);
+
+        verify(operations).resolveClass(any());
+    }
+
+    @Test
+    public void allowedClassIsNotLoadedByParent() throws Exception {
+        temporaryClassLoader.loadClass(Person.class.getName());
+
+        verify(operations, never()).loadClass(eq(Person.class.getName()), anyBoolean());
+    }
+
+    @Test
+    public void excludedClassLoadedByParent() throws Exception {
+        temporaryClassLoader.loadClass("java.lang.Object");
+
+        verify(operations).loadClass(eq("java.lang.Object"), anyBoolean());
+    }
+
+    @Test
+    public void classIsCorrectlyLoadedFromRealInstance() throws Exception {
+        TemporaryClassLoader temporaryClassLoader = new TemporaryClassLoader(Thread.currentThread().getContextClassLoader());
+        Class<?> type = temporaryClassLoader.loadClass(Person.class.getName());
+
+        assertThat(type).isNotNull();
+        assertThat(type.getName()).isEqualTo(Person.class.getName());
+    }
+
+    @Test
+    public void classIsCorrectlyLoadedAndResolvedFromRealInstance() throws Exception {
+        TemporaryClassLoader temporaryClassLoader = new TemporaryClassLoader(Thread.currentThread().getContextClassLoader());
+        Class<?> type = temporaryClassLoader.loadClass(Person.class.getName(), true);
+
+        assertThat(type).isNotNull();
+        assertThat(type.getName()).isEqualTo(Person.class.getName());
+    }
+
+    @Test
+    public void classesAreCorrectlyExcluded() {
+        String[] expectedExclusions = new String[] {
+                "java.lang.Object",
+                "javafx.application.Application",
+                "javax.crypto.Cipher",
+                "oracle.jrockit.jfr.DCmd",
+                "org.omg.CosNaming.Binding",
+                "org.w3c.dom.Entity",
+                "org.xml.sax.Parser",
+                "sun.security.pkcs11.KeyCache",
+                "javassist.ClassPool",
+                "net.bytebuddy.ByteBuddy",
+                "org.apache.commons.logging.Log",
+                "org.apache.log4j.Logger",
+                "org.eclipse.jetty.http.HttpURI",
+                "org.glassfish.jersey.server.ApplicationHandler",
+                "org.slf4j.Logger"
+        };
+        for (String className : expectedExclusions) {
+            assertThat(temporaryClassLoader.isExcluded(className))
+                    .describedAs("Expected \"%s\" to be an excluded class", className)
+                    .isTrue();
+        }
+    }
+
+    @Test
+    public void nullStreamCausesClassNotFound() throws Exception {
+        when(operations.getResourceAsStream(anyString())).thenReturn(null);
+
+        assertThatThrownBy(() -> temporaryClassLoader.loadClass(Person.class.getName(), false))
+                .isInstanceOf(ClassNotFoundException.class)
+                .hasMessageContaining(Person.class.getName());
+    }
+
+    @Test
+    public void errorReadingResourceCausesClassNotFound() throws Exception {
+        doThrow(IOException.class).when(operations).copyStreams(any(), any());
+
+        assertThatThrownBy(() -> temporaryClassLoader.loadClass(Person.class.getName()))
+                .isInstanceOf(ClassNotFoundException.class)
+                .hasMessageContaining(Person.class.getName());
+    }
+
+}

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/UnitOfWorkAwareProxyFactoryTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/UnitOfWorkAwareProxyFactoryTest.java
@@ -9,7 +9,7 @@ import io.dropwizard.lifecycle.setup.LifecycleEnvironment;
 import io.dropwizard.logging.BootstrapLogging;
 import io.dropwizard.setup.Environment;
 import org.assertj.core.data.MapEntry;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -17,9 +17,6 @@ import org.junit.rules.ExpectedException;
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.EntityTransaction;
-import javax.persistence.PersistenceException;
-import java.lang.reflect.Method;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -32,16 +29,17 @@ public class UnitOfWorkAwareProxyFactoryTest {
         BootstrapLogging.bootstrap();
     }
 
-    private EntityManagerFactory entityManagerFactory;
-    private EntityManager sharedEntityManager;
+    private static EntityManagerFactory entityManagerFactory;
+    private static EntityManager sharedEntityManager;
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
-    @Before
-    public void setUp() throws Exception {
+    @BeforeClass
+    public static void setUp() throws Exception {
         final EntityManagerBundle<?> bundle = mock(EntityManagerBundle.class);
         final Environment environment = mock(Environment.class);
+        when(bundle.name()).thenReturn("test-bundle");
         when(environment.lifecycle()).thenReturn(mock(LifecycleEnvironment.class));
         when(environment.metrics()).thenReturn(new MetricRegistry());
 

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/entity/PersonType.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/entity/PersonType.java
@@ -1,0 +1,6 @@
+package com.scottescue.dropwizard.entitymanager.entity;
+
+public enum PersonType {
+    THOSE_WHO_INDENT_WITH_SPACES,
+    SCOURGE_OF_THE_EARTH;
+}

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/entity/Personable.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/entity/Personable.java
@@ -1,0 +1,9 @@
+package com.scottescue.dropwizard.entitymanager.entity;
+
+import java.lang.annotation.*;
+
+@Target({ElementType.METHOD, ElementType.CONSTRUCTOR, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface Personable {
+}


### PR DESCRIPTION
Upgrading to Hibernate 5.1.0.  I'm also implementing the _PersistenceUnitInfoImp#getNewTempClassLoader_ method, which Hibernate 5.x now uses when bootstrapping the EntityManagerFactory.

Resolves #18 
