### PR TITLE
Adding support for scanning multiple packages for JPA entities

### DIFF
--- a/src/test/java/com/scottescue/dropwizard/entitymanager/ScanningEntityManagerBundleTest.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/ScanningEntityManagerBundleTest.java
@@ -1,9 +1,10 @@
 package com.scottescue.dropwizard.entitymanager;
 
 import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg.FakeEntity1;
-import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg.FakeEntity2;
 import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg.deep.DeepFakeEntity;
 import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg.deep.deeper.DeeperFakeEntity;
+import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg2.FakeEntity2;
+import com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg3.FakeEntity3;
 import io.dropwizard.Configuration;
 import io.dropwizard.db.PooledDataSourceFactory;
 import io.dropwizard.setup.Environment;
@@ -12,7 +13,9 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class ScanningEntityManagerBundleTest {
+
     @Test
+    @SuppressWarnings("unchecked")
     public void testFindEntityClassesFromDirectory() {
         String packageWithEntities = "com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg";
         ScanningEntityManagerBundle bundle = new ScanningEntityManagerBundle(packageWithEntities) {
@@ -28,7 +31,31 @@ public class ScanningEntityManagerBundleTest {
 
         assertThat(bundle.getEntities()).containsOnly(
                 FakeEntity1.class,
+                DeepFakeEntity.class,
+                DeeperFakeEntity.class);
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void testFindEntityClassesFromMultipleDirectories() {
+        String root = "com.scottescue.dropwizard.entitymanager.entity.fake.entities.";
+
+        ScanningEntityManagerBundle bundle = new ScanningEntityManagerBundle(
+                root.concat("pckg"), root.concat("pckg2"), root.concat("pckg3")) {
+            @Override
+            public void run(Object o, Environment environment) throws Exception {
+            }
+
+            @Override
+            public PooledDataSourceFactory getDataSourceFactory(Configuration configuration) {
+                return null;
+            }
+        };
+
+        assertThat(bundle.getEntities()).containsOnly(
+                FakeEntity1.class,
                 FakeEntity2.class,
+                FakeEntity3.class,
                 DeepFakeEntity.class,
                 DeeperFakeEntity.class);
     }

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/entity/fake/entities/pckg/FakeEntity2.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/entity/fake/entities/pckg/FakeEntity2.java
@@ -1,8 +1,0 @@
-package com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg;
-
-import javax.persistence.Entity;
-
-@Entity
-public class FakeEntity2 {
-
-}

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/entity/fake/entities/pckg2/FakeEntity2.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/entity/fake/entities/pckg2/FakeEntity2.java
@@ -1,0 +1,8 @@
+package com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg2;
+
+import javax.persistence.Entity;
+
+@Entity
+public class FakeEntity2 {
+
+}

--- a/src/test/java/com/scottescue/dropwizard/entitymanager/entity/fake/entities/pckg3/FakeEntity3.java
+++ b/src/test/java/com/scottescue/dropwizard/entitymanager/entity/fake/entities/pckg3/FakeEntity3.java
@@ -1,0 +1,8 @@
+package com.scottescue.dropwizard.entitymanager.entity.fake.entities.pckg3;
+
+import javax.persistence.Entity;
+
+@Entity
+public class FakeEntity3 {
+
+}


### PR DESCRIPTION
Refactoring ScanningEntityManagerBundle to accept 1 or more paths that should be scanned for JPA entities.

Resolves #22
